### PR TITLE
Fix allowing 1000 character length file name in cwrapper

### DIFF
--- a/MultiNest_v3.12/cwrapper.f90
+++ b/MultiNest_v3.12/cwrapper.f90
@@ -118,7 +118,7 @@ module cnested
 	integer :: i, context_f
 
 	fnest_root = ' '
-	do i = 1, 100
+	do i = 1, 1000
 		if (nest_root(i) == C_NULL_CHAR) then
 			exit
 		else

--- a/MultiNest_v3.12_CMake/multinest/src/cwrapper.f90
+++ b/MultiNest_v3.12_CMake/multinest/src/cwrapper.f90
@@ -118,7 +118,7 @@ module cnested
 	integer :: i, context_f
 
 	fnest_root = ' '
-	do i = 1, 100
+	do i = 1, 1000
 		if (nest_root(i) == C_NULL_CHAR) then
 			exit
 		else

--- a/MultiNest_v3.12_CMake/multinest/src/example_eggbox_C++/eggbox.cc
+++ b/MultiNest_v3.12_CMake/multinest/src/example_eggbox_C++/eggbox.cc
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
 	int pWrap[ndims];				// which parameters to have periodic boundary conditions?
 	for(int i = 0; i < ndims; i++) pWrap[i] = 0;
 	
-	char root[100] = "chains/eggboxCC-";			// root for output files
+	char root[1000] = "chains/eggboxCC-";			// root for output files
 	
 	int seed = -1;					// random no. generator seed, if < 0 then take the seed from system clock
 	

--- a/MultiNest_v3.12_CMake/multinest/src/example_eggbox_C/eggbox.c
+++ b/MultiNest_v3.12_CMake/multinest/src/example_eggbox_C/eggbox.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 	int pWrap[ndims];				// which parameters to have periodic boundary conditions?
 	for(i = 0; i < ndims; i++) pWrap[i] = 0;
 	
-	char root[100] = "chains/eggboxC-";		// root for output files
+	char root[1000] = "chains/eggboxC-";		// root for output files
 	
 	int seed = -1;					// random no. generator seed, if < 0 then take the seed from system clock
 	


### PR DESCRIPTION
The FORTRAN code now allows 1000 character length file names, but there's a minor bug in the C wrapper which means that the file names still get truncated at 100 characters. This PR fixes that bug.